### PR TITLE
Updated nodemon dependency to avoid flatstream-map package

### DIFF
--- a/packages/automerge-server-test/package.json
+++ b/packages/automerge-server-test/package.json
@@ -23,6 +23,6 @@
     "ws": "^6.0.0"
   },
   "devDependencies": {
-    "nodemon": "^1.18.4"
+    "nodemon": "^2.0.2"
   }
 }


### PR DESCRIPTION
The old version of nodemon (1.x) uses a deprecated dependency that was removed due to security implications. 